### PR TITLE
Add macOS SwiftUI ChatGPT app

### DIFF
--- a/ChatGPTChatApp/ChatGPTChatApp/ChatGPTChatApp.entitlements
+++ b/ChatGPTChatApp/ChatGPTChatApp/ChatGPTChatApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/ChatGPTChatApp/ChatGPTChatApp/ChatGPTChatAppApp.swift
+++ b/ChatGPTChatApp/ChatGPTChatApp/ChatGPTChatAppApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct ChatGPTChatAppApp: App {
+    @StateObject private var viewModel = ChatViewModel()
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/ChatGPTChatApp/ChatGPTChatApp/ChatMessage.swift
+++ b/ChatGPTChatApp/ChatGPTChatApp/ChatMessage.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct ChatMessage: Identifiable, Codable {
+    enum Role: String, Codable {
+        case user
+        case assistant
+    }
+    let id = UUID()
+    let role: Role
+    let content: String
+}
+
+struct ChatHistory: Codable {
+    var messages: [ChatMessage]
+}

--- a/ChatGPTChatApp/ChatGPTChatApp/ChatViewModel.swift
+++ b/ChatGPTChatApp/ChatGPTChatApp/ChatViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var alertItem: AlertItem?
+
+    private let service = OpenAIService()
+    private let logURL: URL
+
+    init() {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        logURL = documents.appendingPathComponent("chat_log.txt")
+        loadHistory()
+    }
+
+    func sendMessage(_ text: String) async {
+        let userMessage = ChatMessage(role: .user, content: text)
+        messages.append(userMessage)
+        await saveHistory()
+        do {
+            if let response = try await service.send(messages: messages) {
+                messages.append(response)
+                await saveHistory()
+            }
+        } catch {
+            alertItem = AlertItem(message: error.localizedDescription)
+        }
+    }
+
+    private func loadHistory() {
+        guard let data = try? Data(contentsOf: logURL) else { return }
+        if let history = try? JSONDecoder().decode(ChatHistory.self, from: data) {
+            messages = history.messages
+        }
+    }
+
+    private func saveHistory() async {
+        let history = ChatHistory(messages: messages)
+        if let data = try? JSONEncoder().encode(history) {
+            try? data.write(to: logURL, options: .atomic)
+        }
+    }
+}
+
+struct AlertItem: Identifiable {
+    let id = UUID()
+    let message: String
+}

--- a/ChatGPTChatApp/ChatGPTChatApp/ContentView.swift
+++ b/ChatGPTChatApp/ChatGPTChatApp/ContentView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: ChatViewModel
+    @State private var inputText: String = ""
+    var body: some View {
+        VStack {
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading) {
+                        ForEach(viewModel.messages) { message in
+                            HStack {
+                                if message.role == .user {
+                                    Spacer()
+                                    Text(message.content)
+                                        .padding()
+                                        .background(Color.blue.opacity(0.2))
+                                        .cornerRadius(8)
+                                } else {
+                                    Text(message.content)
+                                        .padding()
+                                        .background(Color.gray.opacity(0.2))
+                                        .cornerRadius(8)
+                                    Spacer()
+                                }
+                            }
+                            .id(message.id)
+                        }
+                    }
+                }
+                .onChange(of: viewModel.messages.count) { _ in
+                    if let last = viewModel.messages.last {
+                        scrollProxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+            HStack {
+                TextField("Type a message", text: $inputText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Send") {
+                    send()
+                }
+                .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding()
+        }
+        .alert(item: $viewModel.alertItem) { item in
+            Alert(title: Text("Error"), message: Text(item.message), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    private func send() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        inputText = ""
+        Task {
+            await viewModel.sendMessage(text)
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(ChatViewModel())
+    }
+}

--- a/ChatGPTChatApp/ChatGPTChatApp/Info.plist
+++ b/ChatGPTChatApp/ChatGPTChatApp/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/ChatGPTChatApp/ChatGPTChatApp/OpenAIService.swift
+++ b/ChatGPTChatApp/ChatGPTChatApp/OpenAIService.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+struct OpenAIChatRequest: Codable {
+    struct Message: Codable {
+        let role: String
+        let content: String
+    }
+    let model: String
+    let messages: [Message]
+}
+
+struct OpenAIChatResponse: Codable {
+    struct Choice: Codable {
+        struct Message: Codable {
+            let role: String
+            let content: String
+        }
+        let message: Message
+    }
+    let choices: [Choice]
+}
+
+final class OpenAIService {
+    private let apiKey: String
+
+    init(apiKey: String = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? "") {
+        self.apiKey = apiKey
+    }
+
+    func send(messages: [ChatMessage]) async throws -> ChatMessage? {
+        guard !apiKey.isEmpty else { throw OpenAIError.missingAPIKey }
+        let url = URL(string: "https://api.openai.com/v1/chat/completions")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let requestMessages = messages.map { OpenAIChatRequest.Message(role: $0.role.rawValue, content: $0.content) }
+        let body = OpenAIChatRequest(model: "gpt-3.5-turbo", messages: requestMessages)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw OpenAIError.invalidResponse
+        }
+        let decoded = try JSONDecoder().decode(OpenAIChatResponse.self, from: data)
+        guard let message = decoded.choices.first?.message else { return nil }
+        return ChatMessage(role: .assistant, content: message.content.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    enum OpenAIError: LocalizedError {
+        case missingAPIKey
+        case invalidResponse
+        case decodingError
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAPIKey:
+                return "Missing OpenAI API Key"
+            case .invalidResponse:
+                return "Invalid response from server"
+            case .decodingError:
+                return "Failed to decode response"
+            }
+        }
+    }
+}

--- a/ChatGPTChatApp/README.md
+++ b/ChatGPTChatApp/README.md
@@ -1,0 +1,11 @@
+# ChatGPTChatApp
+
+Simple macOS SwiftUI chat app that communicates with OpenAI's ChatGPT.
+
+## Building
+1. Open `ChatGPTChatApp` folder in Xcode.
+2. Ensure your macOS deployment target is macOS 11 or newer.
+3. Add your OpenAI API key to the environment variable `OPENAI_API_KEY` in the scheme's run configuration.
+4. Build and run using your Personal Team.
+
+The conversation log is saved to `chat_log.txt` in your Documents folder.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Logankreuzer.github.io
+# LoganKreuzer Chat Apps
+
+This repository contains SwiftUI code for a macOS chat app that communicates with OpenAI's ChatGPT and saves the conversation locally.
+
+See the `ChatGPTChatApp` directory for the full project source.


### PR DESCRIPTION
## Summary
- add a new `ChatGPTChatApp` project with SwiftUI views and view model
- integrate an OpenAI API service
- automatically persist conversation history to `Documents/chat_log.txt`
- enable App Sandbox with network client entitlement
- document build instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686a416544f08331a494e2acf6b1af2a